### PR TITLE
.config에 default_permissions 값이 없으면 KeyError 발생

### DIFF
--- a/models.py
+++ b/models.py
@@ -99,9 +99,15 @@ class PageOperationMixin(object):
     def metadata(self):
         return self.parse_metadata(self.body)
 
+    def get_default_permission(self):
+        try:
+            return WikiPage.yaml_by_title(u'.config')['service']['default_permissions']
+        except KeyError:
+            return {'read':['all'], 'write':['login']}
+
     def can_read(self, user, default_acl=None):
         if default_acl is None:
-            default_acl = WikiPage.yaml_by_title(u'.config')['service']['default_permissions']
+            default_acl = self.get_default_permission()
 
         acl = self.acl_read.split(',') if self.acl_read is not None and len(self.acl_read) != 0 else []
         if len(acl) == 0:
@@ -122,7 +128,7 @@ class PageOperationMixin(object):
 
     def can_write(self, user, default_acl=None):
         if default_acl is None:
-            default_acl = WikiPage.yaml_by_title(u'.config')['service']['default_permissions']
+            default_acl = self.get_default_permission()
 
         acl = self.acl_write.split(',') if self.acl_write is not None and len(self.acl_write) != 0 else []
         if len(acl) == 0:


### PR DESCRIPTION
.config에 default_permissions 설정이 안 되어 있어서 에러가 나길래 default_permissions 가져오는 걸 함수로 뺐는데, 
config 읽어오는 부분을 좀 정리하는게 좋을 듯 싶네요.
