### PR TITLE
FIX codemaster css rendering problem

### DIFF
--- a/templates/wikipage.form.html
+++ b/templates/wikipage.form.html
@@ -11,6 +11,13 @@
     .CodeMirror-scroll {
         overflow-y: hidden;
         overflow-x: auto;
+
+        /* Fixes first line rendering problem in Chrome,
+           removing CSS code for hiding scrollbars (uses auto-resizing) */
+        margin-bottom: 0px;
+        padding-bottom: 0px;
+        margin-right: 0px;
+        padding-right: 0px;
     }
     .CodeMirror pre {
         font-family: NanumGothicCoding, "Courier New", Courier, monospace;


### PR DESCRIPTION
- Chrome has a weird bug covering the first line
- seems that `.CodeMirror-scroll` is the cause
  - mainly `margin-bottom` and `padding-bottom`
  - used for hiding the scrollbar in CodeMirror
- since ecogwiki always use auto-resize
  - set `margin` and `padding` to 0
