### PR TITLE
Fix Wikpage.get_config

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,5 @@
 import optparse
+import os
 import sys
 import unittest2
 
@@ -13,7 +14,19 @@ def main(sdk_path, test_path):
     sys.path.insert(0, sdk_path)
     import dev_appserver
     dev_appserver.fix_sys_path()
-    suite = unittest2.loader.TestLoader().discover(test_path)
+    # tests/ directory
+    if os.path.isdir(test_path):
+        suite = unittest2.loader.TestLoader().discover(test_path)
+    # test_file.py
+    elif os.path.isfile(test_path):
+        test_path, test_file = test_path.rsplit(os.path.sep, 1)
+        suite = unittest2.loader.TestLoader().discover(test_path, test_file)
+    # tests.module.TestCase
+    else:
+        module_name, class_name = test_path.rsplit('.', 1)
+        module = __import__(module_name, fromlist=[module_name])
+        testcase = getattr(module, class_name)
+        suite = unittest2.loader.TestLoader().loadTestsFromTestCase(testcase)
     unittest2.TextTestRunner(verbosity=2).run(suite)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -319,6 +319,36 @@ class WikiYamlParserTest(unittest.TestCase):
     def test_empty_page(self):
         self.assertEqual(main.DEFAULT_CONFIG, WikiPage.get_config())
 
+class WikiPageGetConfigTest(unittest.TestCase):
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        self.testbed.init_taskqueue_stub()
+        
+        #
+        self.config_page = WikiPage.get_by_title(u'.config')
+        self.config_page.update_content(u'''
+          admin:
+            email: janghwan@gmail.com
+          service:
+            default_permissions:
+              read: [all]
+              write: [login]
+        ''', 0, '')
+
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def test_update_by_dot_config_page(self):
+        config = WikiPage.get_config()
+        self.assertEqual(config['admin']['email'], 'janghwan@gmail.com')
+
+    def test_updates_partial_configurations(self):
+        config = WikiPage.get_config()
+        self.assertEqual(config['service']['title'], '')
 
 class WikiPageRelatedPageUpdatingTest(unittest.TestCase):
     def setUp(self):
@@ -838,3 +868,5 @@ class UserPreferencesTest(unittest.TestCase):
         UserPreferences.save(self.user, u'김경수')
 
         self.assertEquals(u'김경수', UserPreferences.get_by_email('user@example.com').userpage_title)
+
+


### PR DESCRIPTION
You should do recursive update on `dict`s, instead of just value update.

Added `WikiPageGetConfigTest` at `tests/test_models.py`. I'm not sure if this test suits the testing standard for the project. Any corrections are welcome.

Also added more conventions to run_tests.py ;)
