### PR TITLE
FIX redirecting to absolute path

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -497,6 +497,19 @@ class RESTfulAPITest(unittest.TestCase):
         self.assertEqual(u'', page.body)
         self.assertEqual(0, page.revision)
 
+    def test_redirect_in_absolute_path(self):
+        self.browser.login('ak@gmailcom', 'ak')
+
+        # GET edit form of "New/page"
+        self.browser.get('/New/page')
+        self.browser.get(self.browser.query_link(".//a[@id='edit']"))
+
+        # PUT "New page"
+        self.browser.submit(".//form[@class='editform']", {'body': 'Hello', 'revision': '0', 'preview': '0'})
+
+        self.assertEqual(303, self.browser.res.status_code)
+        self.assertEqual('http://localhost/New/page', self.browser.res.headers['Location'])
+
 
 class Browser(object):
     def __init__(self):

--- a/views.py
+++ b/views.py
@@ -117,10 +117,9 @@ class WikiPageHandler(webapp2.RequestHandler):
             self.response.headers['X-Message'] = 'Successfully updated.'
             quoted_path = urllib2.quote(path.replace(' ', '_'))
             restype = self._get_restype()
-            if restype == 'default':
-                self.response.headers['Location'] = quoted_path
-            else:
-                self.response.headers['Location'] = str('/%s?_type=%s' % (quoted_path, restype))
+            self.response.headers['Location'] = str('/' + quoted_path)
+            if restype != 'default':
+                self.response.headers['Location'] += str('?_type=%s' % restype)
             self.response.status = 303
 
         except ValueError as e:
@@ -183,10 +182,9 @@ class WikiPageHandler(webapp2.RequestHandler):
             self.response.headers['X-Message'] = 'Successfully updated.'
             quoted_path = urllib2.quote(path.replace(' ', '_'))
             restype = self._get_restype()
-            if restype == 'default':
-                self.response.headers['Location'] = quoted_path
-            else:
-                self.response.headers['Location'] = str('/%s?_type=%s' % (quoted_path, restype))
+            self.response.headers['Location'] = str('/' + quoted_path)
+            if restype != 'default':
+                self.response.headers['Location'] += str('?_type=%s' % restype)
             self.response.status = 303
         except ConflictError as e:
             self.response.status = 409


### PR DESCRIPTION
`views.py` behaves weirdly when there is a slash inside the title.
- was: `POST` and `PUT` redirecting to **relative path** on update
- caused error: editing page titled `page/2` redirects to `page/page/2`
- fixed: add leading slash
