### PR TITLE
FIX behavior on /sp.search?q=ecog on default restype

### DIFF
--- a/views.py
+++ b/views.py
@@ -584,6 +584,10 @@ class SpecialPageHandler(webapp2.RequestHandler):
                 titles = [t for t in titles if t.find(q) != -1]
             self.response.headers['Content-Type'] = 'application/json'
             set_response_body(self.response, json.dumps([q, list(titles)]), head)
+        elif restype == 'default':
+            quoted_path = urllib2.quote(q.encode('utf8').replace(' ', '_'))
+            self.response.headers['Location'] = '/' + quoted_path
+            self.response.status = 303
         else:
             self.abort(400, 'Unknown type: %s' % restype)
 


### PR DESCRIPTION
- Currently the `get_search()` method only deals with `json` types and raises 400 on others.
- However, since the search form is targeted to `GET /sp.search`, it could even happen on browser when javascript is not enabled.
- 4 lines of codes added to deal with the default case.

I'm not sure about what the `opensearch` resformat does, so feel free to correct it if needed.
