### PR TITLE
ADD body placeholder with body= parameter on request

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -380,6 +380,26 @@ class PageResourceTest(unittest.TestCase):
         page = WikiPage.get_by_title(u'New page')
         self.assertEqual(u'Hello', page.body)
 
+    def test_provide_placeholder_with_param_when_editing_new_page(self):
+        self.browser.login('ak@gmailcom', 'ak')
+
+        # GET edit form of "New page"
+        self.browser.get('/New_page?view=edit&body=some%20pre%20value')
+        body = self.browser.query(".//form[@class='editform']//*[@name='body']")[0]
+        self.assertEqual(body.text, 'some pre value')
+
+    def test_no_placeholder_when_editing_existing_page(self):
+        self.browser.login('ak@gmailcom', 'ak')
+
+        # Create page
+        page = WikiPage.get_by_title(u'New page')
+        page.update_content(u'Hello', 0)
+
+        # GET edit form of "New page"
+        self.browser.get('/New_page?view=edit&body=some%20pre%20value')
+        body = self.browser.query(".//form[@class='editform']//*[@name='body']")[0]
+        self.assertEqual(body.text, 'Hello')
+
     def test_update_existing_page(self):
         self.browser.login('ak@gmail.com', 'ak')
 

--- a/views.py
+++ b/views.py
@@ -102,7 +102,7 @@ class PageHandler(webapp2.RequestHandler):
                 self.response.location += '?%s' % self.request.query
             self.response.status = 303
             return
-        elif self.request.path_qs.find('%20') != -1:
+        elif self.request.path.find('%20') != -1:
             self.response.location = '%s' % self.request.path_qs.replace('%20', '_')
             self.response.status = 303
             return
@@ -161,6 +161,9 @@ class PageHandler(webapp2.RequestHandler):
                 self.response.headers['Content-Type'] = 'text/html; charset=utf-8'
                 set_response_body(self.response, html, head)
             elif view == 'edit':
+                # insert body from params if revision is 0
+                if page.revision == 0 and self.request.GET.get('body'):
+                    page.body = self.request.GET.get('body')
                 html = template(self.request, 'wikipage.form.html', {'page': page, 'conflict': None})
                 self.response.headers['Content-Type'] = 'text/html; charset=utf-8'
                 set_response_body(self.response, html, head)


### PR DESCRIPTION
This adds a feature to pre-write the text in body with GET request. Since this is actually a feature request, feel free to discuss about this feature here.

This makes the following URL possible

```
http://www.ecogwiki.com/new_feature?view=edit&body=a%20new%20new%20feature
```

which can let a direct URL with prewritten text possible.

You can even make bookmarklets like these:

```
javascript:(function(){var d=new Date();var s=('스크랩/'+d.getFullYear()+"-"+("0"+(d.getMonth()+1)).replace(/^0(..)$/, "$1")+"-"+("0"+d.getDate()).replace(/^0(..)$/, "$1")+'/'+document.title).replace(/ /g, '_');var b='출처: '+location.href;window.open('http://ecogwiki-jangxyz.appspot.com/'+encodeURI(s)+'?view=edit&body='+encodeURIComponent(b),'_blank');})()
```

If you think this is too hacky, check this poll about this feature:

https://docs.google.com/forms/d/10-I7z8yc46BTUUT9AI-hT7S_yK0kOML5z2gcL7z3ZfY/viewform?entry_2025209923=then%20think%20again

---

commit log:

ADD body placeholder with body= parameter on request
- only if it is an empty page (rev=0)

wonderful things can happen :)
