### PR TITLE
[제안] Add page edit resource

### DIFF
--- a/resources.py
+++ b/resources.py
@@ -150,10 +150,21 @@ class PageResource(PageLikeResource):
         new_body = self.req.POST['body']
         comment = self.req.POST.get('comment', '')
 
+        view    = self.req.GET.get('view', self.default_view)
+        restype = get_restype(self.req, 'html')
+
+        # POST to edit form, not content
+        if restype == 'html' and view == 'edit':
+            if page.revision == 0:
+                page.body = new_body
+            representation = self.get_representation(page)
+            representation.respond(self.res, head=False)
+            return
+
+        # POST to content
         try:
             page.update_content(page.body + new_body, page.revision, comment, self.user)
             quoted_path = urllib2.quote(self.path.replace(' ', '_'))
-            restype = get_restype(self.req, 'html')
             if restype == 'html':
                 self.res.location = str('/' + quoted_path)
             else:

--- a/views.py
+++ b/views.py
@@ -4,7 +4,7 @@ import caching
 from models import WikiPage
 from google.appengine.ext import deferred
 from representations import TemplateRepresentation
-from resources import RedirectResource, PageResource, RevisionResource, RevisionListResource,\
+from resources import RedirectResource, PageResource, PageEditResource, RevisionResource, RevisionListResource,\
     RelatedPagesResource, WikiqueryResource, TitleListResource, SearchResultResource,\
     TitleIndexResource, PostListResource, ChangeListResource, UserPreferencesResource,\
     SchemaResource
@@ -24,7 +24,10 @@ class PageHandler(webapp2.RequestHandler):
         elif self.request.GET.get('rev', '') != '':
             resource = RevisionResource(self.request, self.response, path, self.request.GET.get('rev', ''))
         else:
-            resource = PageResource(self.request, self.response, path)
+            if self.request.GET.get('view') == 'edit':
+                resource = PageEditResource(self.request, self.response, path)
+            else:
+                resource = PageResource(self.request, self.response, path)
         resource.get(head)
 
     def post(self, path):
@@ -34,7 +37,10 @@ class PageHandler(webapp2.RequestHandler):
         elif method == 'PUT':
             return self.put(path)
 
-        resource = PageResource(self.request, self.response, path)
+        if self.request.GET.get('view') == 'edit':
+            resource = PageEditResource(self.request, self.response, path)
+        else:
+            resource = PageResource(self.request, self.response, path)
         resource.post()
 
     def put(self, path):


### PR DESCRIPTION
PageResource 에서 `view=edit`인 경우를 별도의 PageEditResource를 분리하자는 제안입니다.

배경:
- `/PAGE`와 `/PAGE?view=edit` 두 경우를 별도의 리소스로 나누어서 바라보면, 페이지 편집폼에 더 많은 액션을 추가할 수 있습니다.
- 예를 들어, `POST /some-page?view=edit`의 body에 내용을 적어넣어 미리 내용이 채워진 편집폼을 제공할 수 있습니다.

---

예시: 다음의 링크로 북마클릿을 만들어서 사용해보세요 (1064 bytes):

```
javascript:!function(){function a(){var a="";return window.getSelection?a=window.getSelection().toString():document.selection.createRange&&(a=document.selection.createRange().text),a}var b=new Date,c=("\uc2a4\ud06c\ub7a9/"+b.getFullYear()+"-"+("0"+(b.getMonth()+1)).replace(/^0(..)$/,"$1")+"-"+("0"+b.getDate()).replace(/^0(..)$/,"$1")+"/"+document.title.replace(/\?/g,"")).replace(/ /g,"_").replace(/#/g,"_"),d="\ucd9c\ucc98: url::"+location.href+"\n\n- - -\n\n",e=document.getElementsByTagName("body")[0],f=document.createElement("button");f.setAttribute("style","position:fixed;right:0;top:0;"),f.innerText="ecog!",e.appendChild(f),f.onclick=function(){for(var g=a().split("\n"),h=0;h<g.length;h++)d+="> "+g[h]+"\n";var i=document.createElement("form");i.target="_blank",i.method="POST",i.action="http://ecogwiki-jangxyz.appspot.com/"+encodeURI(c)+"?view=edit",i.setAttribute("style","display:none;"),i.innerHTML='<textarea name="body">'+d.replace(/&gt;/g,">").replace(/&lt;/,"<")+"</textarea>",e.appendChild(i),i.submit(),e.removeChild(i),e.removeChild(f)}}();
```

사용방법:
1. 페이지에서 북마클릿을 클릭한다. 우측상단에 버튼이 생긴다.
2. 원하는 만큼의 내용을 select 하고, 버튼 클릭
3. select한 내용이 붙은 스크랩 페이지가 나타남. 원 페이지에서 임시로 생겼던 버튼은 사라짐

---

두 개의 커밋으로 나누어서 올렸는데, 첫번째는 기존 `PageResource`에서 if 문으로 분기한 방식이고, 두번째 커밋은 별도의 `PageEditResource`로 리팩토링했습니다. 이는 post가 완전히 다른 기능을 수행해서 코드를 이해하기가 더 어렵다고 판단해서입니다.
기존 Resource 구현 방식은 여러개의 view를 기대하는 방식인데, 어떤 방식으로 구현하면 위 기능을 하는 코드가 더 붙기 좋은지 의견을 알려주세요.
