### PR TITLE
넘어온 페이지 표시하기

### DIFF
--- a/templates/wikipage.html
+++ b/templates/wikipage.html
@@ -148,6 +148,13 @@ window.fbAsyncInit = function() {
         </div>
         {% endif %}
 
+		{% if redirected_from %}
+        <div class="message">
+            <div class="close">x</div>
+			<p>Redirected from <a href="{{ redirected_from|to_rel_path }}">{{ redirected_from }}</a></p>
+        </div>
+		{% endif %}
+
         {% if page.is_old_revision %}
         <div class="message">
             <p>You are seeing an old version of the page. Go to <a href="{{ page.absolute_latest_url|e }}">latest version</a></p>


### PR DESCRIPTION
리다이렉트 시 '어느어느 페이지에서 넘어왔다'는 메시지를 알려주는 기능을 넣어봤습니다.

사용자는 동일한 내용을 지닌 다른 이름의 페이지가 있을 때 이를 하나로 관리하고 싶을 때
`.redirect` 기능을 쓸 수 있는데,
어느 페이지와 연결되어 있는지 잘 파악하지 못해서 위치를 잃어버릴 위험이 있기 때문입니다.

구현:
- redirect가 일어날 시 cookie의 `ecogwiki_redirected_from`에 값을 저장한 뒤(max age 60s)에 303을 날리고,
- `PageLikeResource.represent_html_default`에서 늘 뽑아봅니다.
- `wikipage.html`에서 기본 `{{ message }}` 와 충돌할지 어떨지 몰라 다른 곳을 파서 출력합니다.  

스크린샷:

![redirected-from-](https://f.cloud.github.com/assets/52015/1895762/38c25ca6-7b5b-11e3-8440-93646e7599f5.png)

---

이를 더 확장해서 '여기로 리다이렉트 되는 다른 페이지들'을 볼 수 있는 어떠한 기능도 있었으면 좋겠네요.
