### PR TITLE
FIX TocGenerator to accept attributed headings

### DIFF
--- a/models/toc_generator.py
+++ b/models/toc_generator.py
@@ -4,7 +4,7 @@ import hashlib
 
 
 class TocGenerator(object):
-    re_headings = ur'<h(\d)>(.+?)</h\d>'
+    re_headings = ur'<h(\d)\b[^>]*>(.+?)</h\d>'
 
     def __init__(self, html):
         self._html = html

--- a/tests/test_toc_generator.py
+++ b/tests/test_toc_generator.py
@@ -105,6 +105,16 @@ class PathTest(unittest.TestCase):
     def test_duplicated_path(self):
         self.assertRaises(ValueError, self.t.generate_path, [[u'T1', []], [u'T1', []]])
 
+class ExtractHeadingsTest(unittest.TestCase):
+    def test_header_with_attributes(self):
+        html = '''
+        <h1>a one</h1>
+        <h1 id="user-defined-id">a two</h1>
+        <h1>a three</h1>
+        '''
+        headings = TocGenerator.extract_headings(html)
+        self.assertEqual(len(headings), 3);
+
 
 class HTMLGenerationTest(unittest.TestCase):
     def test_strip_html_in_headings(self):


### PR DESCRIPTION
[Attribute List Extension](http://pythonhosted.org/Markdown/extensions/attr_list.html#block-level)을 사용하여 heading에 attribute을 줄 수 있는데, 이 경우 ToC에서 빠져서 이상하게 차례가 나타나는 문제가 있습니다.

예:

```
# Introduction
Once upon a time there lived two princess lived Elsa and Anna.

# Climax # {: #the-cool-part }
Boom! Zap! Aghhhh....!

# Ending
And they lived happily ever after. The end.
```

attr_list 플러그인이 먼저 `<h1 id="the-cool-part">Climax</h1>`로 렌더링하기 때문에 단순히 `<h\d>`만을 체크하는 현재의 `TocGenerator`의 정규식으로는 잡지 못하고 있습니다.

이  개선이 이루어지면, 기계적으로 생성된 읽기 힘든 anchor가 아니라 사용자가 중요하다고 생각하는 이름을 직접 URL에 사용할 수 있습니다 :)

> 예: check out the cool part of the story at `http://ecogwiki.com/Frozen#the-cool-part`!

---

`commit log:`
- TocGenerator skips any headings with attributes (via RE)
- an attribute may be added using AttrList extension
- a skipped heading was not being displayed in ToC
- now it is :)
