### PR TITLE
FIX heading error message to provide more info

### DIFF
--- a/models/toc_generator.py
+++ b/models/toc_generator.py
@@ -11,13 +11,16 @@ class TocGenerator(object):
         self._index = 0
 
     def validate(self):
+        return not self.is_invalid()
+
+    def is_invalid(self):
         try:
             headings = TocGenerator.extract_headings(self._html)
             outlines = self.generate_outline(headings)
             self.generate_path(outlines)
-            return True
-        except ValueError:
             return False
+        except ValueError as e:
+            return e.message
 
     def add_toc(self):
         """Add table of contents to HTML"""
@@ -66,7 +69,7 @@ class TocGenerator(object):
 
         cur_lev = headings[0][0]
         if cur_lev != 1:
-            raise ValueError('Headings should start from H1')
+            raise ValueError('Headings should start from H1 but found: <H%d>%s</H%d>' % (cur_lev, headings[0][1], cur_lev))
 
         _, result = self._outline_children(headings, 0, cur_lev)
         return result
@@ -99,7 +102,7 @@ class TocGenerator(object):
                 index -= 1
                 break
             else:
-                raise ValueError('Invalid level of headings')
+                raise ValueError('Invalid level of headings: expected H%d or H%d but found <H%d>%s</H%d>' % (lev-1, lev, curlev, curtitle, curlev))
 
         return index, result
 

--- a/models/wiki_page.py
+++ b/models/wiki_page.py
@@ -279,8 +279,9 @@ class WikiPage(ndb.Model, PageOperationMixin):
             raise ValueError('Invalid revision number: %d' % base_revision)
 
         # check headings
-        if not TocGenerator(md.convert(new_body)).validate():
-            raise ValueError("Duplicate paths not allowed")
+        invalid_reason = TocGenerator(md.convert(new_body)).is_invalid() 
+        if invalid_reason:
+            raise ValueError(invalid_reason)
 
         return new_data, new_md
 

--- a/tests/test_toc_generator.py
+++ b/tests/test_toc_generator.py
@@ -116,3 +116,33 @@ class HTMLGenerationTest(unittest.TestCase):
         """
         t = TocGenerator(html)
         self.assertEqual(1, len(re.findall(ur'Blah', t.add_toc())))
+
+class ValidateTest(unittest.TestCase):
+    def test_duplicate_path_name_should_metion_reason(self):
+        html = '''
+            <h1>a one</h1>
+            <h1>a two</h1>
+            <h1>a one</h1>
+            <h1>two</h1>
+            <h1>three</h1>
+        '''
+        reason = TocGenerator(html).is_invalid()
+        self.assertIn('a one', reason)
+
+    def test_invalid_level_of_headings_should_mention_reason(self):
+        html = '''
+            <h1>one</h1>
+            <h1>two</h1>
+            <h3>three</h3>
+        '''
+        reason = TocGenerator(html).is_invalid()
+        self.assertIn('<h3>three</h3>', reason.lower())
+
+    def test_heading_not_startig_from_h1_should_mention_reason(self):
+        html = '''
+            <h2>two</h2>
+            <h3>three</h3>
+        '''
+        reason = TocGenerator(html).is_invalid()
+        self.assertIn('<h2>two</h2>', reason.lower())
+


### PR DESCRIPTION
헤딩 (`#heading`)이 잘못되었을 때 나타나는 에러 메세지가 너무 모호해서 사용자가 알아듣기 힘듭니다.

다음과 같은 메세지들이 이유를 더 잘 나타내도록 변경했습니다:
- Headings should start from H1
  
  ```
  Headings should start from H1 but found: <H2>헤딩</H2>
  ```
- Invalid level of headings
  
  ```
  Invalid level of headings: expected H1 or H2 but found <H3>나 여기 아니야?</H3>
  ```
- Duplicate paths not allowed
  
  ```
  Duplicate paths not allowed: 나 또 나오면 안돼?
  ```

이렇게 표현하기 위해 `validate()` 메소드 대신 `is_invalid()`라는 메소드를 추가해 이유를 설명하도록 바꾸었습니다. 이렇게 하면 기존에 의도했던 대로 에러 이유를 재사용할 수 있습니다.
이름이 마음에 안 들면... 적당히 바꿔주세요 

---

`commit message:`

change:
- add `toc_generator.is_invalid` method to return error msg and
- `wiki_page.validate_new_content` calls `is_invalid` instead of `validate`
- and use the reason returned for error message
- `toc_generator..validate` is left for backward compatibility, if any

provides:
- 'Headings should start from H1' returns explicit error heading
- 'Invalid level of headings' tells you which and why
- 'Duplicate paths not allowed' shows you which one
