### PR TITLE
Fix schema parse re (2)

### DIFF
--- a/models/page_operation_mixin.py
+++ b/models/page_operation_mixin.py
@@ -19,7 +19,19 @@ class PageOperationMixin(object):
     re_img = re.compile(ur'<(.+?)>[\n\t\s]*<img( .+? )/>[\n\t\s]*</(.+?)>')
     re_metadata = re.compile(ur'^\.([^\s]+)(\s+(.+))?$')
     re_data = re.compile(ur'({{|\[\[)(?P<name>[^\]}]+)::(?P<value>[^\]}]+)(}}|\]\])')
-    re_yaml_schema = re.compile(ur'(?:\s{4}|\t)#!yaml/schema[\n\r]+(((?:\s{4}|\t).+?[\n\r]+?)+)')
+    re_yaml_schema = re.compile(r'''
+                                    # HEADER
+            (?:\s{4}|\t)            #   leading tab or 4 space followed by (non-capture)
+            \#!yaml/schema          #   `#!yaml/schema`
+            [\n\r]+                 #   new line(s)
+            (                       # CONTENT (group 1)
+                (                   #   multiple lines of  (group 2)
+                    (?:\s{4}|\t)    #   leading tab or 4 space followed by (non-capture)
+                    .+?             #   any string
+                    [\n\r]+?        #   new line(s)
+                )+
+            )
+    ''', re.VERBOSE)
     re_conflicted = re.compile(ur'<<<<<<<.+=======.+>>>>>>>', re.DOTALL)
     re_special_titles_years = re.compile(ur'^(10000|\d{1,4})( BCE)?$')
     re_special_titles_dates = re.compile(ur'^((?P<month>January|February|March|'

--- a/models/page_operation_mixin.py
+++ b/models/page_operation_mixin.py
@@ -19,7 +19,7 @@ class PageOperationMixin(object):
     re_img = re.compile(ur'<(.+?)>[\n\t\s]*<img( .+? )/>[\n\t\s]*</(.+?)>')
     re_metadata = re.compile(ur'^\.([^\s]+)(\s+(.+))?$')
     re_data = re.compile(ur'({{|\[\[)(?P<name>[^\]}]+)::(?P<value>[^\]}]+)(}}|\]\])')
-    re_yaml_schema = re.compile(ur'(?:\s{4}|\t)#!yaml/schema[\n\r]+(((?:\s{4}|\t).+[\n\r]+?)+)')
+    re_yaml_schema = re.compile(ur'(?:\s{4}|\t)#!yaml/schema[\n\r]+(((?:\s{4}|\t).+?[\n\r]+?)+)')
     re_conflicted = re.compile(ur'<<<<<<<.+=======.+>>>>>>>', re.DOTALL)
     re_special_titles_years = re.compile(ur'^(10000|\d{1,4})( BCE)?$')
     re_special_titles_dates = re.compile(ur'^((?P<month>January|February|March|'
@@ -311,7 +311,7 @@ class PageOperationMixin(object):
         try:
             parsed = yaml.load(m.group(1))
         except ParserError as e:
-            raise ValueError(e.message)
+            raise ValueError(e.message or u'invalid YAML format:<pre>%s</pre>' % m.group(0))
 
         # check if it's dict
         if type(parsed) != dict:

--- a/resources.py
+++ b/resources.py
@@ -189,6 +189,7 @@ class PageResource(PageLikeResource):
             set_response_body(self.res, html, False)
 
     def put(self):
+        print 'put'
         page = self.load()
 
         revision = int(self.req.POST['revision'])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -59,11 +59,6 @@ class SchemaTest(AppEngineTestCase):
         self.assertEqual([0, 0], url['cardinality'])
         self.assertEqual(['URL'], url['type']['ranges'])
 
-    def xtest_re_match(self):
-        body = u'''\t#!yaml/schema\r\n    url: "http://anotherfam.kr/"\r\n\r\n\r\n[[\uc81c\uc791\ub450\ub808]]\ub97c ...\r\n'''
-        data = PageOperationMixin.parse_schema_yaml(body)
-        self.assertEqual(data['url'], 'http://anotherfam.kr/')
-
 
 class CustomTypeAndPropertyTest(AppEngineTestCase):
     def setUp(self):
@@ -215,6 +210,11 @@ class YamlSchemaDataTest(AppEngineTestCase):
         self.assertEqual({u'Book/author': [u'AK']}, page.outlinks)
         self.assertEquals({'name': u'Hello', 'isbn': u'1234567890', 'schema': u'Thing/CreativeWork/Book/', 'author': u'AK'},
                           dict((k, v.pvalue) for k, v in page.data.items()))
+
+    def test_re_match(self):
+        body = u'''\t#!yaml/schema\r\n    url: "http://anotherfam.kr/"\r\n\r\n\r\n[[\uc81c\uc791\ub450\ub808]]\ub97c ...\r\n'''
+        data = PageOperationMixin.parse_schema_yaml(body)
+        self.assertEqual(data['url'], 'http://anotherfam.kr/')
 
     def test_list_value(self):
         page = self.update_page(u'.schema Book\n\n    #!yaml/schema\n    author: [AK, TK]\n\nHello', u'Hello')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -59,6 +59,11 @@ class SchemaTest(AppEngineTestCase):
         self.assertEqual([0, 0], url['cardinality'])
         self.assertEqual(['URL'], url['type']['ranges'])
 
+    def xtest_re_match(self):
+        body = u'''\t#!yaml/schema\r\n    url: "http://anotherfam.kr/"\r\n\r\n\r\n[[\uc81c\uc791\ub450\ub808]]\ub97c ...\r\n'''
+        data = PageOperationMixin.parse_schema_yaml(body)
+        self.assertEqual(data['url'], 'http://anotherfam.kr/')
+
 
 class CustomTypeAndPropertyTest(AppEngineTestCase):
     def setUp(self):


### PR DESCRIPTION
본문에 들어가는 YAML 구조를 파싱하는 정규표현식에 오류가 있어 개선했습니다. (테스트 추가)
- 현행: 내용을 capture하는 `.+`가 개행문자(`\r`)까지 포함하는 문제가 있음
- 수정: non-greedy `.+?`로 변경

기타: 
- `yaml.load`가 던지는 `ParseError`의 인스턴스는 `message` 프로퍼티가 비어 있어 사용자한테 에러 내용이 전달되지 않아 이를 수정함
  - 에러 메세지에 `<pre>`가 들어가는 것은 잠재적인 개선이 필요할 수 있음
- 정규식의 가독성이 떨어져서 python에서 지원하는 `re.VERBOSE`로 가독성 증대
