### PR TITLE
FIX parsing yaml schema when tab and space are mixed

### DIFF
--- a/models/page_operation_mixin.py
+++ b/models/page_operation_mixin.py
@@ -28,7 +28,7 @@ class PageOperationMixin(object):
                 (                   #   multiple lines of  (group 2)
                     (?:\s{4}|\t)    #   leading tab or 4 space followed by (non-capture)
                     .+?             #   any string
-                    [\n\r]+?        #   new line(s)
+                    [\n\r]+         #   new line(s)
                 )+
             )
     ''', re.VERBOSE)
@@ -322,7 +322,8 @@ class PageOperationMixin(object):
 
         # parse
         try:
-            parsed = yaml.load(m.group(1))
+            captured = m.group(1).replace('\t', '    ')
+            parsed = yaml.load(captured)
         except ParserError as e:
             raise ValueError(e.message or u'invalid YAML format:<pre>%s</pre>' % m.group(0))
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -237,6 +237,13 @@ class YamlSchemaDataTest(AppEngineTestCase):
         page = self.update_page(u'.schema Book\n\n    #!yaml/schema\n    author: AK\n    isbn: "1234567890"\n\nHello')
         self.assertEqual(-1, page.rendered_body.find(u'#!yaml/schema'))
 
+    def test_tab_and_space_mixed(self):
+        body = u'\t#!yaml/schema\r\n    alternateName: 반올림\r\n\turl: http://cafe.daum.net/samsunglabor\r\n    name: "반도체 노동자의 건강과 인권 지킴이"\r\n'
+        data = PageOperationMixin.parse_schema_yaml(body)
+        self.assertEquals(data['name'], u'반도체 노동자의 건강과 인권 지킴이')
+        self.assertEquals(data['alternateName'], u'반올림')
+        self.assertEquals(data['url'], 'http://cafe.daum.net/samsunglabor')
+
 
 class SchemaIndexTest(AppEngineTestCase):
     def setUp(self):


### PR DESCRIPTION
- yaml cannot parse tabs
  - replace with spaces
- nongreedy `[\n\r]+?` catches only the first character of '\r\n'
  - change it into greedy: `[\n\r]+`

has tests :)
