### PR TITLE
FIX greedy re_yaml_schema pattern error

### DIFF
--- a/models/page_operation_mixin.py
+++ b/models/page_operation_mixin.py
@@ -21,12 +21,12 @@ class PageOperationMixin(object):
     re_data = re.compile(ur'({{|\[\[)(?P<name>[^\]}]+)::(?P<value>[^\]}]+)(}}|\]\])')
     re_yaml_schema = re.compile(r'''
                                     # HEADER
-            (?:\s{4}|\t)            #   leading tab or 4 space followed by (non-capture)
+            (?:[ ]{4}|\t)           #   leading tab or 4 space followed by (non-capture)
             \#!yaml/schema          #   `#!yaml/schema`
             [\n\r]+                 #   new line(s)
             (                       # CONTENT (group 1)
                 (                   #   multiple lines of  (group 2)
-                    (?:\s{4}|\t)    #   leading tab or 4 space followed by (non-capture)
+                    (?:[ ]{4}|\t)   #   leading tab or 4 space followed by (non-capture)
                     .+?             #   any string
                     [\n\r]+         #   new line(s)
                 )+

--- a/tests/test_models_rendering.py
+++ b/tests/test_models_rendering.py
@@ -52,6 +52,13 @@ class SimpleExtensionsTest(RenderingTestCase):
         self.assertRenderedText(u'http://x.com/_a_', u'<p><a class="plainurl" href="http://x.com/_a_">http://x.com/_a_</a></p>')
         self.assertRenderedText(u'![Image](http://x.com/_a_)', u'<p class="img-container"><img alt="Image" src="http://x.com/_a_"></p>')
 
+    def test_structure_without_schema(self):
+        body = u'''Hello\r\n\r\n\t#!yaml/schema\n    url: "http://abc.com"\n\nWorld\n'''
+        rendered = PageOperationMixin.render_body(u'Hello', body)
+        self.assertEquals(rendered.replace(u'\n', u''), u'<p>Hello</p><p>World</p>')
+
+
+
 
 class EmbedTest(RenderingTestCase):
     maxDiff = None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -244,6 +244,13 @@ class YamlSchemaDataTest(AppEngineTestCase):
         self.assertEquals(data['alternateName'], u'반올림')
         self.assertEquals(data['url'], 'http://cafe.daum.net/samsunglabor')
 
+    def test_yaml_indent_catching_only_space(self):
+        body = u'''Hello\r\n\r\n\t#!yaml/schema\n    url: "http://abc.com"\n\nWorld\n'''
+        matched = PageOperationMixin.re_yaml_schema.search(body).group(0)
+        self.assertFalse(matched.startswith('\r'))
+        self.assertFalse(matched.startswith('\n'))
+        self.assertTrue(matched.startswith('\t'))
+
 
 class SchemaIndexTest(AppEngineTestCase):
     def setUp(self):


### PR DESCRIPTION
[#78](https://github.com/akngs/ecogwiki/pull/78)이 올바른 FIX 였지만 이로 인해 내부에 있던 에러가 드러남에 따라 추가 FIX 올립니다.

`#!yaml/schema` 구조에서 뒤따르는 newline들까지 모두 삼킴에 따라,
그 앞문단과 뒷문단이 바짝 붙어버려서 별도의 paragraph로 렌더링되지 않는 오류를 수정했습니다.

문제는 이전 FIX가 newline들을 모두 삼킴과는 별도로, 
_indent를 구별할 때 `\s`를 사용하면 선행하는 newline까지 인식하는_ 문제로 인한 것이었습니다.
이에 따라 `\s{4}`를 찾던 이전 패턴을 오직 띄어쓰기만 찾도록 `[ ]{4}` 변경했습니다.

---

using `\s{4}` for indent also captures leading `\n`s, trimming too much newlines.
- changed to: `[ ]{4}`
- tests
  1. `PageOperationMixin.re_yaml_schema` does not capture leading newlines
  2. `PageOperationMixin.render_body` does not trim too much, preserving separate paragraphs
