### PR TITLE
구조화된 schema data에 링크 추가 제안

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -7,6 +7,9 @@ import caching
 import operator
 from markdownext import md_wikilink
 
+from datetime import date
+import logging
+logging.getLogger().setLevel(logging.DEBUG)
 
 SCHEMA_TO_LOAD = [
     'schema.json',
@@ -401,7 +404,7 @@ class TextProperty(TypeProperty):
         self.value = pvalue
 
     def is_wikilink(self):
-        return self.pname == 'name'
+        return True
 
     def render(self):
         if self.is_wikilink():
@@ -464,12 +467,17 @@ class URLProperty(TypeProperty):
             raise ValueError('Invalid URL: %s' % pvalue)
         self.value = pvalue
 
+    def render(self):
+        return u'<a href="%s" class="url" itemprop="url">%s</a>' % (self.value, self.value)
+
 
 class DateProperty(TypeProperty):
     P_DATE = ur'(?P<y>\d+)(-(?P<m>(\d\d|\?\?))-(?P<d>(\d\d|\?\?)))?( (?P<bce>BCE))?'
 
     def __init__(self, itemtype, ptype, pname, pvalue):
         super(DateProperty, self).__init__(itemtype, ptype, pname, pvalue)
+        if isinstance(pvalue, date):
+            pvalue = pvalue.strftime("%Y-%m-%d")
         m = re.match(DateProperty.P_DATE, pvalue)
         if m is None:
             raise ValueError('Invalid value: %s' % pvalue)


### PR DESCRIPTION
`#!yaml/schema` 구역 생성 시 현재는 `Name`에만 걸리는 링크를
모든 값들에 기본적으로 링크를 걸어주는 것을 제안하는 PR입니다.

제안 사항은 다음과 같습니:ㅏ
- `TextProperty`는 항상 링크를 겁니다.
- `URLProperty`는 외부 링크를 겁니다.
- `DateProperty.__init__`에서 pvalue의 type이 datetime.date일 때는 str로 변경해줍니다. (기존에는 여기서 error가 났음)
