### PR TITLE
FIX numeric schema properties

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -412,7 +412,9 @@ class TextProperty(TypeProperty):
 
 class NumberProperty(TypeProperty):
     def __init__(self, itemtype, ptype, pname, pvalue):
+        pvalue = str(pvalue)
         super(NumberProperty, self).__init__(itemtype, ptype, pname, pvalue)
+
         try:
             if pvalue.find('.') == -1:
                 self.value = int(pvalue)
@@ -424,18 +426,21 @@ class NumberProperty(TypeProperty):
 
 class IntegerProperty(NumberProperty):
     def __init__(self, itemtype, ptype, pname, pvalue):
+        pvalue = str(pvalue)
         super(IntegerProperty, self).__init__(itemtype, ptype, pname, pvalue)
 
         try:
             self.value = int(pvalue)
         except ValueError:
             raise ValueError('Invalid integer: %s' % pvalue)
+
         if self.value != float(pvalue):
             raise ValueError('Invalid integer: %s' % pvalue)
 
 
 class FloatProperty(NumberProperty):
     def __init__(self, itemtype, ptype, pname, pvalue):
+        pvalue = str(pvalue)
         super(FloatProperty, self).__init__(itemtype, ptype, pname, pvalue)
 
         try:
@@ -508,6 +513,7 @@ class ISBNProperty(TypeProperty):
     P_ISBN = ur'[\dxX]{10,13}'
 
     def __init__(self, itemtype, ptype, pname, pvalue):
+        pvalue = str(pvalue)
         super(ISBNProperty, self).__init__(itemtype, ptype, pname, pvalue)
         if re.match(ISBNProperty.P_ISBN, pvalue) is None:
             raise ValueError('Invalid ISBN: %s' % pvalue)


### PR DESCRIPTION
- numeric types such as isbn, numberOfPages raises error  assuming pvalue is string

---

현재는 isbn에 숫자만 쳐 넣어도 에러가 나길래 그에 대한 FIX 입니다.

 `self.pvalue`가 숫자를 유지해야 할지 문자열이어야 할지, 어떤 의도로 설계되었는지는 모르겠습니다.
다른 애들이 대부분 `str`이라 일단 일관성 차원에서...
