### PR TITLE
[제안] ADD cache for cardinalities

### DIFF
--- a/caching.py
+++ b/caching.py
@@ -105,6 +105,11 @@ def set_schema_property(prop_name, prop):
 def set_schema_datatype(type_name, prop):
     _set_cache('schema\tdatatype\t%s' % type_name, prop)
 
+def set_cardinalities(key, data):
+    try:
+        return c.set('schema\tcardinalities\t%s' % key, data)
+    except:
+        pass
 
 def set_config(value):
     _set_cache('model\tconfig', value)
@@ -145,6 +150,8 @@ def set_hashbangs(title, value):
     _set_cache('model\thashbangs\t%s' % title, value)
 
 
+
+
 def get_schema_set():
     return _get_cache('schema_set')
 
@@ -164,6 +171,11 @@ def get_schema_property(prop_name):
 def get_schema_datatype(type_name):
     return _get_cache('schema\tdatatype\t%s' % type_name)
 
+def get_cardinalities(key):
+    try:
+        return c.get('schema\tcardinalities\t%s' % key)
+    except:
+        pass
 
 def get_config():
     return _get_cache('model\tconfig')

--- a/schema.py
+++ b/schema.py
@@ -216,8 +216,15 @@ def get_cardinality(itemtype, prop_name):
 
 
 def get_cardinalities(itemtype):
-    return dict((pname, get_cardinality(itemtype, pname))
-                for pname in get_schema(itemtype)['properties'])
+    result = caching.get_cardinalities(itemtype)
+    if result is not None:
+        return result
+
+    properties = get_schema(itemtype)['properties']
+    properties_dict = dict([(pname, get_cardinality(itemtype, pname)) for pname in properties])
+
+    caching.set_cardinalities(itemtype, properties_dict)
+    return properties_dict
 
 
 def humane_item(itemtype, plural=False):
@@ -348,6 +355,7 @@ class SchemaConverter(object):
 
     def check_cardinality(self):
         cardinalities = get_cardinalities(self._itemtype)
+
         for pname, (cfrom, cto) in cardinalities.items():
             if pname not in self._data:
                 num = 0


### PR DESCRIPTION
저장 시 너무 오래 걸려서 성능 개선을 위한 작업을 해보았습니다.
하나의 PUT request를 처리하는데 보통 4초 정도 걸리던걸 1초 대까지 떨어뜨려줍디다.

PUT 요청을 처리하는 동안 구석구석 걸리는 시간을 찍어보았는데,
가장 많이 걸리는 애가 `schema.py`에 있는 `get_cardinalities` 였습니다.

기본인 `Articles` type이 50개 정도의 properties를 들고 있는데, 각각은 캐싱이 돼 있어서 금방 가져오지만
50개를 일일히 가져오는 작업을 하면 1.5s 정도 소요되더라구요.

그래서 get_properties를 통채로 caching에 넣었습니다.
기본은 ProcessRequestCache로 in-memory이기에 쿨하게 memcache에 저장.
PUT 반응 속도가 1.7s 까지 떨어지네요.

layered cache라 아마 `caching.set_schema`나 `caching.set_property`를 할 때 저것도 invalidate를 시켜줘야 할지도 모르겠습니다만..
일단 의견이 어떨지 궁금해서 PR 날려봅니다.
