### PR TITLE
set disqus for comment system instead of Facebook comment

### DIFF
--- a/templates/wikipage.html
+++ b/templates/wikipage.html
@@ -242,10 +242,29 @@ window.fbAsyncInit = function() {
 
 {% if page.published_at and 'pt' not in page.metadata %}
 <div class="social">
+    {% if config.service.disqus_shortname %}
+    <!-- Disqus { -->
+    <div id="disqus_thread"></div>
+    <script type="text/javascript">
+        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+        var disqus_shortname = '{{ config.service.disqus_shortname }}'; // required: replace example with your forum shortname
+
+        /* * * DON'T EDIT BELOW THIS LINE * * */
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+    <!-- } Disqus -->
+    {% else %}
     <!-- Facebook { -->
     <div class="fb-like" data-href="http://{{ config.service.domain }}{{ page.absolute_latest_url|e }}" data-width="300" data-layout="standard" data-show-faces="true" data-send="true"></div>
     <div class="fb-comments" data-href="http://{{ config.service.domain }}{{ page.absolute_latest_url|e }}" data-width="630"></div>
     <!-- } Facebook -->
+    {% endif %}
 </div>
 {% endif %}
 


### PR DESCRIPTION
Published article social comment is useful, but someone do not like Facebook comment. If he set disqus_shortname to config.service, he would see disqus comment like as http://e.biohackers.net/Ecogwiki를_이용한_지식정보관리 
